### PR TITLE
feat(FEC-14917): Player V7| SEO| EAD and Captions limits

### DIFF
--- a/src/providers/response-types/kaltura-asset.ts
+++ b/src/providers/response-types/kaltura-asset.ts
@@ -28,6 +28,8 @@ export interface KalturaCaptionAssetArgs {
   content: [];
   displayOnPlayer: boolean;
   usage: number | string;
+  accuracy: number;
+  language: string;
 }
 
 export class KalturaCaptionAsset {
@@ -36,6 +38,8 @@ export class KalturaCaptionAsset {
   public content: Array<any>;
   public displayOnPlayer: boolean;
   public usage: number | string;
+  public accuracy: number;
+  public language: string;
 
   constructor(captionAsset: KalturaCaptionAssetArgs) {
     this.id = captionAsset.id;
@@ -43,5 +47,7 @@ export class KalturaCaptionAsset {
     this.content = [];
     this.displayOnPlayer = captionAsset.displayOnPlayer;
     this.usage = captionAsset.usage;
+    this.accuracy = captionAsset.accuracy;
+    this.language = captionAsset.language;
   }
 }

--- a/src/seo-assets-service.ts
+++ b/src/seo-assets-service.ts
@@ -49,12 +49,72 @@ export class SeoAssetsService {
     return kalturaAssets;
   }
 
-  private async loadCaptionData(captions: KalturaCaptionAsset[], ks: string): Promise<void> {
-    captions = captions.filter((caption) => Number(caption.usage) === 1 || caption.displayOnPlayer === true);
-    if (!this.config.addAllCaptions) {
-      captions = captions.slice(0, 10);
+  private selectTenLanguages(captions: Map<string, KalturaCaptionAsset[]>): Map<string, KalturaCaptionAsset[]> {
+    const selectedLanguages: Array<[string, KalturaCaptionAsset[]]> = [];
+    let foundUsageOne = false;
+
+    for (const [language, languageCaptions] of captions) {
+      const hasUsageOne = languageCaptions.some(c => Number(c.usage) === 1);
+
+      if (selectedLanguages.length < 10) {
+        selectedLanguages.push([language, languageCaptions]);
+        if (hasUsageOne) {
+          foundUsageOne = true;
+        }
+      } else {
+        if (!foundUsageOne && hasUsageOne) {
+          selectedLanguages[9] = [language, languageCaptions];
+          break;
+        }
+        if (foundUsageOne) {
+          break;
+        }
+      }
     }
+    return new Map(selectedLanguages);
+  }
+  
+  private selectCaptions(captions: KalturaCaptionAsset[]): KalturaCaptionAsset[] {
+    let captionsByLanguage = this.groupCaptionsByLanguage(captions);
+    if (!this.config.addAllCaptions) {
+      captionsByLanguage = this.selectTenLanguages(captionsByLanguage);
+    }
+    const selectedCaptions: KalturaCaptionAsset[] = [];
+    for (const [, languageCaptions] of captionsByLanguage) {
+      const bestCaptionsForLanguage = this.mostAccuratePerUsage(languageCaptions);
+      selectedCaptions.push(...bestCaptionsForLanguage);
+    }
+    return selectedCaptions;
+  }
+
+  private groupCaptionsByLanguage(captions: KalturaCaptionAsset[]): Map<string, KalturaCaptionAsset[]> {
+    const captionsByLanguage = new Map<string, KalturaCaptionAsset[]>();
     for (const caption of captions) {
+      if (!captionsByLanguage.has(caption.language)) {
+        captionsByLanguage.set(caption.language, []);
+      }
+      captionsByLanguage.get(caption.language)!.push(caption);
+    }
+    return captionsByLanguage;
+  }
+
+  private mostAccuratePerUsage(captions: KalturaCaptionAsset[]): KalturaCaptionAsset[] {
+    const byUsage = new Map<number, KalturaCaptionAsset>();
+    for (const caption of captions) {
+      const usage = Number(caption.usage);
+      const existingCaption = byUsage.get(usage);
+      if (!existingCaption || caption.accuracy > existingCaption.accuracy) {
+        byUsage.set(usage, caption);
+      }
+    }
+    return Array.from(byUsage.values());
+  }
+
+
+  private async loadCaptionData(captions: KalturaCaptionAsset[], ks: string): Promise<void> {
+    const selectedCaptions = this.selectCaptions(captions);
+
+    for (const caption of selectedCaptions) {
       try {
         const contentData: Map<string, any> = await (this.player as any).provider.doRequest(
           [{ loader: ServeAssetlLoader, params: { captions: [caption] } }],

--- a/src/seo-assets-service.ts
+++ b/src/seo-assets-service.ts
@@ -78,7 +78,7 @@ export class SeoAssetsService {
     return new Map(selectedLanguages);
   }
 
-  private selectCaptions(captions: KalturaCaptionAsset[]): KalturaCaptionAsset[] {
+  private selectOptimalCaptions(captions: KalturaCaptionAsset[]): KalturaCaptionAsset[] {
     let captionsByLanguage = this.groupCaptionsByLanguage(captions);
     if (!this.config.addAllCaptions) {
       captionsByLanguage = this.selectTenLanguages(captionsByLanguage);
@@ -115,7 +115,7 @@ export class SeoAssetsService {
   }
 
   private async loadCaptionData(captions: KalturaCaptionAsset[], ks: string): Promise<void> {
-    const selectedCaptions = this.selectCaptions(captions);
+    const selectedCaptions = this.selectOptimalCaptions(captions);
 
     for (const caption of selectedCaptions) {
       try {

--- a/src/seo-assets-service.ts
+++ b/src/seo-assets-service.ts
@@ -54,7 +54,7 @@ export class SeoAssetsService {
     let foundUsageOne = false;
 
     for (const [language, languageCaptions] of captions) {
-      const hasUsageOne = languageCaptions.some(c => Number(c.usage) === 1);
+      const hasUsageOne = languageCaptions.some((c) => Number(c.usage) === 1);
 
       if (selectedLanguages.length < 10) {
         selectedLanguages.push([language, languageCaptions]);
@@ -73,7 +73,7 @@ export class SeoAssetsService {
     }
     return new Map(selectedLanguages);
   }
-  
+
   private selectCaptions(captions: KalturaCaptionAsset[]): KalturaCaptionAsset[] {
     let captionsByLanguage = this.groupCaptionsByLanguage(captions);
     if (!this.config.addAllCaptions) {
@@ -109,7 +109,6 @@ export class SeoAssetsService {
     }
     return Array.from(byUsage.values());
   }
-
 
   private async loadCaptionData(captions: KalturaCaptionAsset[], ks: string): Promise<void> {
     const selectedCaptions = this.selectCaptions(captions);

--- a/src/seo-assets-service.ts
+++ b/src/seo-assets-service.ts
@@ -51,23 +51,27 @@ export class SeoAssetsService {
 
   private selectTenLanguages(captions: Map<string, KalturaCaptionAsset[]>): Map<string, KalturaCaptionAsset[]> {
     const selectedLanguages: Array<[string, KalturaCaptionAsset[]]> = [];
-    let foundUsageOne = false;
+    let hasEAD = false,
+      hasRegular = false;
 
     for (const [language, languageCaptions] of captions) {
-      const hasUsageOne = languageCaptions.some((c) => Number(c.usage) === 1);
+      const hasEADCaption = languageCaptions.some((c) => Number(c.usage) === 1);
+      const hasRegularCaption = languageCaptions.some((c) => Number(c.usage) === 0);
 
       if (selectedLanguages.length < 10) {
         selectedLanguages.push([language, languageCaptions]);
-        if (hasUsageOne) {
-          foundUsageOne = true;
-        }
+        hasEAD ||= hasEADCaption;
+        hasRegular ||= hasRegularCaption;
       } else {
-        if (!foundUsageOne && hasUsageOne) {
-          selectedLanguages[9] = [language, languageCaptions];
+        if (hasEAD && hasRegular) {
           break;
         }
-        if (foundUsageOne) {
-          break;
+        if (!hasEAD && hasEADCaption) {
+          selectedLanguages[9] = [language, languageCaptions];
+          hasEAD = true;
+        } else if (!hasRegular && hasRegularCaption) {
+          selectedLanguages[9] = [language, languageCaptions];
+          hasRegular = true;
         }
       }
     }


### PR DESCRIPTION
### Description of the Changes

handling captions data:

1. sort caption per language and add one regular caption and one EAD caption (if exists)
2. if there is multiple captions file for the same language, the caption with the highest accuracy will be added.
3. add maximum 20 captions (10 languages: one regular and one EAD)
4. ensure that we always have EAD caption and one regular caption at minimum (if those are available).

solves [FEC-14917](https://kaltura.atlassian.net/browse/FEC-14917)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14917]: https://kaltura.atlassian.net/browse/FEC-14917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ