### PR TITLE
fix(FEC-14917): Player V7| SEO| EAD and Captions limits

### DIFF
--- a/src/providers/captions-loader.ts
+++ b/src/providers/captions-loader.ts
@@ -33,6 +33,10 @@ export class CaptionsLoader implements ILoader {
       filter: {
         entryIdEqual: this._entryId,
         objectType: 'KalturaCaptionAssetFilter'
+      },
+      pager: {
+        pageSize: 500,
+        objectType: 'KalturaFilterPager'
       }
     };
     this.requests.push(captionsListRequest);


### PR DESCRIPTION
### Description of the Changes

by default backend return only 30 captions, adding pager in order to get all captions

solves [FEC-14917](https://kaltura.atlassian.net/browse/FEC-14917)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14917]: https://kaltura.atlassian.net/browse/FEC-14917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ